### PR TITLE
Update `github-script` to `v7`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Log GHA ID JWT Claims
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           let webIdentityToken = await core.getIDToken();


### PR DESCRIPTION
This bumps the `github-script` action from `v6` to `v7`, which [bumps Node.js from 16 to 20](https://github.com/actions/github-script/releases/tag/v7.0.0).